### PR TITLE
fix: parse user messages correctly

### DIFF
--- a/src/parser/packet/mod.rs
+++ b/src/parser/packet/mod.rs
@@ -23,14 +23,7 @@ impl Packet {
         let end_position = reader.read_fixed32()? as u64 + reader.pos();
 
         while reader.pos() < end_position {
-            // This can fail for some unknown reason. If it does, we should
-            // continue and act as if nothing happened.
-            let res = Message::try_new(reader);
-            let message = if let Ok(message) = res {
-                message
-            } else {
-                continue;
-            };
+            let message = Message::try_new(reader)?;
             trace!(?message);
             messages.push(message);
         }


### PR DESCRIPTION
Hi!

I figured ou what was wrong with the user messages. `CodedInputStream::read_message()` first reads a varint32 which is supposed to be the length of the following serialized message but `CSVCMsg_UserMessage::msg_data()` doesn't have this length.

This is my first week of using Rust, so any advice for how to make the code more idiomatic is appreciated.